### PR TITLE
Checks for consistency of site numbers between y, occ.covs and det.covs

### DIFF
--- a/R/PGOcc.R
+++ b/R/PGOcc.R
@@ -34,20 +34,20 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
 
     # Some initial checks -------------------------------------------------
     if (missing(data)) {
-      stop("error: data must be specified")
+      stop("data must be specified")
     }
     if (!is.list(data)) {
-      stop("error: data must be a list")
+      stop("data must be a list")
     }
     names(data) <- tolower(names(data))
     if (missing(occ.formula)) {
-      stop("error: occ.formula must be specified")
+      stop("occ.formula must be specified")
     }
     if (missing(det.formula)) {
-      stop("error: det.formula must be specified")
+      stop("det.formula must be specified")
     }
     if (!'y' %in% names(data)) {
-      stop("error: detection-nondetection data y must be specified in data")
+      stop("detection-nondetection data y must be specified in data")
     }
     y <- as.matrix(data$y)
     if (!'occ.covs' %in% names(data)) {
@@ -57,14 +57,26 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
         }
         data$occ.covs <- matrix(1, dim(y)[1], 1)
       } else {
-        stop("error: occ.covs must be specified in data for an occupancy model with covariates")
+        stop("occ.covs must be specified in data for an occupancy model with covariates")
       }
     }
     if (!is.matrix(data$occ.covs) & !is.data.frame(data$occ.covs)) {
-      stop("error: occ.covs must be a matrix or data frame")
+      stop("occ.covs must be a matrix or data frame")
     }
+    
+    
+    ## begin code block 'Heibl1'
+    ## assuming sites are in rows
+    if (dim(y)[[1]] != dim(data$occ.covs)[[1]]){
+      stop("number of sites in encounter history 'y' (J = ", dim(y)[[1]],
+           ") does not match number of sites in site-specific covariates 'occ.covs' (J = ", 
+           dim(data$occ.covs)[[1]], ").")
+    }
+    ## end code block 'Heibl1'
+    
+    
     if (sum(is.na(data$occ.covs)) > 0) {
-      stop("error: missing covariate values in data$occ.covs. Remove these sites from all data or impute non-missing values.")
+      stop("missing covariate values in data$occ.covs. Remove these sites from all data or impute non-missing values.")
     }
     if (!'det.covs' %in% names(data)) {
       if (det.formula == ~ 1) {
@@ -73,24 +85,36 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
 	}
         data$det.covs <- list(int = rep(1, dim(y)[1]))
       } else {
-        stop("error: det.covs must be specified in data for a detection model with covariates")
+        stop("det.covs must be specified in data for a detection model with covariates")
       }
     }
     if (!is.list(data$det.covs)) {
-      stop("error: det.covs must be a list of matrices, data frames, and/or vectors")
+      stop("det.covs must be a list of matrices, data frames, and/or vectors")
     }
+    
+    
+    ## begin code block 'Heibl2'
+    ## assuming sites are in rows
+    if (dim(y)[[1]] != dim(data$det.covs)[[1]]){
+      stop("number of sites in encounter history 'y' (J = ", dim(y)[[1]],
+           ") does not match number of sites in site-specific covariates 'det.covs' (J = ", 
+           dim(data$occ.covs)[[1]], ").")
+    }
+    ## end code block 'Heibl2'
+    
+    
     if (missing(n.samples)) {
-      stop("error: n.samples must be specified")
+      stop("n.samples must be specified")
     }
     if (n.burn > n.samples) {
-      stop("error: n.burn must be less than n.samples")
+      stop("n.burn must be less than n.samples")
     }
     if (n.thin > n.samples) {
-      stop("error: n.thin must be less than n.samples")
+      stop("n.thin must be less than n.samples")
     }
     if (!missing(k.fold)) {
       if (!is.numeric(k.fold) | length(k.fold) != 1 | k.fold < 2) {
-        stop("error: k.fold must be a single integer value >= 2")  
+        stop("k.fold must be a single integer value >= 2")  
       }
     }
 
@@ -121,10 +145,10 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
       occ.re.names <- sapply(findbars(occ.formula), all.vars)
       for (i in 1:length(occ.re.names)) {
         if (is(data$occ.covs[, occ.re.names[i]], 'factor')) {
-          stop(paste("error: random effect variable ", occ.re.names[i], " specified as a factor. Random effect variables must be specified as numeric.", sep = ''))
+          stop(paste("random effect variable ", occ.re.names[i], " specified as a factor. Random effect variables must be specified as numeric.", sep = ''))
         } 
         if (is(data$occ.covs[, occ.re.names[i]], 'character')) {
-          stop(paste("error: random effect variable ", occ.re.names[i], " specified as character. Random effect variables must be specified as numeric.", sep = ''))
+          stop(paste("random effect variable ", occ.re.names[i], " specified as character. Random effect variables must be specified as numeric.", sep = ''))
         }
       }
     }
@@ -133,10 +157,10 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
       det.re.names <- sapply(findbars(det.formula), all.vars)
       for (i in 1:length(det.re.names)) {
         if (is(data$det.covs[, det.re.names[i]], 'factor')) {
-          stop(paste("error: random effect variable ", det.re.names[i], " specified as a factor. Random effect variables must be specified as numeric.", sep = ''))
+          stop(paste("random effect variable ", det.re.names[i], " specified as a factor. Random effect variables must be specified as numeric.", sep = ''))
         } 
         if (is(data$det.covs[, det.re.names[i]], 'character')) {
-          stop(paste("error: random effect variable ", det.re.names[i], " specified as character. Random effect variables must be specified as numeric.", sep = ''))
+          stop(paste("random effect variable ", det.re.names[i], " specified as character. Random effect variables must be specified as numeric.", sep = ''))
         }
       }
     }
@@ -145,17 +169,17 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
     # y -------------------------------
     y.na.test <- apply(y.big, 1, function(a) sum(!is.na(a)))
     if (sum(y.na.test == 0) > 0) {
-      stop("error: some sites in y have all missing detection histories. Remove these sites from all objects in the 'data' argument, then use 'predict' to obtain predictions at these locations if desired.")
+      stop("some sites in y have all missing detection histories. Remove these sites from all objects in the 'data' argument, then use 'predict' to obtain predictions at these locations if desired.")
     }
     # occ.covs ------------------------
     if (sum(is.na(data$occ.covs)) != 0) {
-      stop("error: missing values in occ.covs. Please remove these sites from all objects in data or somehow replace the NA values with non-missing values (e.g., mean imputation).") 
+      stop("missing values in occ.covs. Please remove these sites from all objects in data or somehow replace the NA values with non-missing values (e.g., mean imputation).") 
     }
     # det.covs ------------------------
     if (!binom) {
       for (i in 1:ncol(data$det.covs)) {
         if (sum(is.na(data$det.covs[, i])) > sum(is.na(y.big))) {
-          stop("error: some elements in det.covs have missing values where there is an observed data value in y. Please either replace the NA values in det.covs with non-missing values (e.g., mean imputation) or set the corresponding values in y to NA where the covariate is missing.") 
+          stop("some elements in det.covs have missing values where there is an observed data value in y. Please either replace the NA values in det.covs with non-missing values (e.g., mean imputation) or set the corresponding values in y to NA where the covariate is missing.") 
         }
       }
       # Misalignment between y and det.covs
@@ -174,7 +198,7 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
     # det.covs when binom == TRUE -----
     if (binom) {
       if (sum(is.na(data$det.covs)) != 0) {
-        stop("error: missing values in site-level det.covs. Please remove these sites from all objects in data or somehow replace the NA values with non-missing values (e.g., mean imputation).") 
+        stop("missing values in site-level det.covs. Please remove these sites from all objects in data or somehow replace the NA values with non-missing values (e.g., mean imputation).") 
       }
     }
 
@@ -187,7 +211,7 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
       x.re.names <- colnames(X.re)
       x.names <- tmp[[2]]
     } else {
-      stop("error: occ.formula is misspecified")
+      stop("occ.formula is misspecified")
     }
     # Get RE level names
     re.level.names <- lapply(data$occ.covs[, x.re.names, drop = FALSE],
@@ -201,7 +225,7 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
       x.p.re.names <- colnames(X.p.re)
       x.p.names <- tmp[[2]]
     } else {
-      stop("error: det.formula is misspecified")
+      stop("det.formula is misspecified")
     }
     p.re.level.names <- lapply(data$det.covs[, x.p.re.names, drop = FALSE],
 			       function (a) sort(unique(a)))
@@ -278,25 +302,25 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
     # beta -----------------------
     if ("beta.normal" %in% names(priors)) {
       if (!is.list(priors$beta.normal) | length(priors$beta.normal) != 2) {
-        stop("error: beta.normal must be a list of length 2")
+        stop("beta.normal must be a list of length 2")
       }
       mu.beta <- priors$beta.normal[[1]]
       sigma.beta <- priors$beta.normal[[2]]
       if (length(mu.beta) != p.occ & length(mu.beta) != 1) {
         if (p.occ == 1) {
-          stop(paste("error: beta.normal[[1]] must be a vector of length ",
+          stop(paste("beta.normal[[1]] must be a vector of length ",
 	  	     p.occ, " with elements corresponding to betas' mean", sep = ""))
 	} else {
-          stop(paste("error: beta.normal[[1]] must be a vector of length ",
+          stop(paste("beta.normal[[1]] must be a vector of length ",
 	  	     p.occ, " or 1 with elements corresponding to betas' mean", sep = ""))
         }
       }
       if (length(sigma.beta) != p.occ & length(sigma.beta) != 1) {
         if (p.occ == 1) {
-          stop(paste("error: beta.normal[[2]] must be a vector of length ",
+          stop(paste("beta.normal[[2]] must be a vector of length ",
 		   p.occ, " with elements corresponding to betas' variance", sep = ""))
         } else {
-          stop(paste("error: beta.normal[[2]] must be a vector of length ",
+          stop(paste("beta.normal[[2]] must be a vector of length ",
 		   p.occ, " or 1 with elements corresponding to betas' variance", sep = ""))
         }
       }
@@ -318,25 +342,25 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
     # alpha -----------------------
     if ("alpha.normal" %in% names(priors)) {
       if (!is.list(priors$alpha.normal) | length(priors$alpha.normal) != 2) {
-        stop("error: alpha.normal must be a list of length 2")
+        stop("alpha.normal must be a list of length 2")
       }
       mu.alpha <- priors$alpha.normal[[1]]
       sigma.alpha <- priors$alpha.normal[[2]]
       if (length(mu.alpha) != p.det & length(mu.alpha) != 1) {
         if (p.det == 1) {
-          stop(paste("error: alpha.normal[[1]] must be a vector of length ",
+          stop(paste("alpha.normal[[1]] must be a vector of length ",
 	  	     p.det, " with elements corresponding to alphas' mean", sep = ""))
 	} else {
-          stop(paste("error: alpha.normal[[1]] must be a vector of length ",
+          stop(paste("alpha.normal[[1]] must be a vector of length ",
 	  	     p.det, " or 1 with elements corresponding to alphas' mean", sep = ""))
         }
       }
       if (length(sigma.alpha) != p.det & length(sigma.alpha) != 1) {
         if (p.det == 1) {
-          stop(paste("error: alpha.normal[[2]] must be a vector of length ",
+          stop(paste("alpha.normal[[2]] must be a vector of length ",
 		   p.det, " with elements corresponding to alphas' variance", sep = ""))
         } else {
-          stop(paste("error: alpha.normal[[2]] must be a vector of length ",
+          stop(paste("alpha.normal[[2]] must be a vector of length ",
 		   p.det, " or 1 with elements corresponding to alphas' variance", sep = ""))
         }
       }
@@ -359,25 +383,25 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
     if (p.occ.re > 0) {
       if ("sigma.sq.psi.ig" %in% names(priors)) {
         if (!is.list(priors$sigma.sq.psi.ig) | length(priors$sigma.sq.psi.ig) != 2) {
-          stop("error: sigma.sq.psi.ig must be a list of length 2")
+          stop("sigma.sq.psi.ig must be a list of length 2")
         }
         sigma.sq.psi.a <- priors$sigma.sq.psi.ig[[1]]
         sigma.sq.psi.b <- priors$sigma.sq.psi.ig[[2]]
         if (length(sigma.sq.psi.a) != p.occ.re & length(sigma.sq.psi.a) != 1) {
           if (p.occ.re == 1) {
-          stop(paste("error: sigma.sq.psi.ig[[1]] must be a vector of length ", 
+          stop(paste("sigma.sq.psi.ig[[1]] must be a vector of length ", 
           	   p.occ.re, " with elements corresponding to sigma.sq.psis' shape", sep = ""))
 	  } else {
-          stop(paste("error: sigma.sq.psi.ig[[1]] must be a vector of length ", 
+          stop(paste("sigma.sq.psi.ig[[1]] must be a vector of length ", 
           	   p.occ.re, " or 1 with elements corresponding to sigma.sq.psis' shape", sep = ""))
           }
         }
         if (length(sigma.sq.psi.b) != p.occ.re & length(sigma.sq.psi.b) != 1) {
           if (p.occ.re == 1) {
-            stop(paste("error: sigma.sq.psi.ig[[2]] must be a vector of length ", 
+            stop(paste("sigma.sq.psi.ig[[2]] must be a vector of length ", 
           	   p.occ.re, " with elements corresponding to sigma.sq.psis' scale", sep = ""))
 	  } else {
-            stop(paste("error: sigma.sq.psi.ig[[2]] must be a vector of length ", 
+            stop(paste("sigma.sq.psi.ig[[2]] must be a vector of length ", 
           	   p.occ.re, " or 1with elements corresponding to sigma.sq.psis' scale", sep = ""))
           }
         }
@@ -402,25 +426,25 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
     if (p.det.re > 0) {
       if ("sigma.sq.p.ig" %in% names(priors)) {
         if (!is.list(priors$sigma.sq.p.ig) | length(priors$sigma.sq.p.ig) != 2) {
-          stop("error: sigma.sq.p.ig must be a list of length 2")
+          stop("sigma.sq.p.ig must be a list of length 2")
         }
         sigma.sq.p.a <- priors$sigma.sq.p.ig[[1]]
         sigma.sq.p.b <- priors$sigma.sq.p.ig[[2]]
         if (length(sigma.sq.p.a) != p.det.re & length(sigma.sq.p.a) != 1) {
           if (p.det.re == 1) {
-            stop(paste("error: sigma.sq.p.ig[[1]] must be a vector of length ", 
+            stop(paste("sigma.sq.p.ig[[1]] must be a vector of length ", 
           	   p.det.re, " with elements corresponding to sigma.sq.ps' shape", sep = ""))
 	  } else {
-            stop(paste("error: sigma.sq.p.ig[[1]] must be a vector of length ", 
+            stop(paste("sigma.sq.p.ig[[1]] must be a vector of length ", 
           	   p.det.re, " or 1 with elements corresponding to sigma.sq.ps' shape", sep = ""))
           }
         }
         if (length(sigma.sq.p.b) != p.det.re & length(sigma.sq.p.b) != 1) {
           if (p.det.re == 1) {
-            stop(paste("error: sigma.sq.p.ig[[2]] must be a vector of length ", 
+            stop(paste("sigma.sq.p.ig[[2]] must be a vector of length ", 
           	     p.det.re, " with elements corresponding to sigma.sq.ps' scale", sep = ""))
 	  } else {
-            stop(paste("error: sigma.sq.p.ig[[2]] must be a vector of length ", 
+            stop(paste("sigma.sq.p.ig[[2]] must be a vector of length ", 
           	     p.det.re, " or 1 with elements corresponding to sigma.sq.ps' scale", sep = ""))
           }
         }
@@ -451,17 +475,17 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
     if ("z" %in% names(inits)) {
       z.inits <- inits$z
       if (!is.vector(z.inits)) {
-        stop(paste("error: initial values for z must be a vector of length ",
+        stop(paste("initial values for z must be a vector of length ",
 		   J, sep = ""))
       }
       if (length(z.inits) != J) {
-        stop(paste("error: initial values for z must be a vector of length ",
+        stop(paste("initial values for z must be a vector of length ",
 		   J, sep = ""))
       }
       z.test <- apply(y.big, 1, max, na.rm = TRUE)
       init.test <- sum(z.inits < z.test)
       if (init.test > 0) {
-        stop("error: initial values for latent occurrence (z) are invalid. Please re-specify inits$z so initial values are 1 if the species is observed at that site.")
+        stop("initial values for latent occurrence (z) are invalid. Please re-specify inits$z so initial values are 1 if the species is observed at that site.")
       }
     } else {
       # In correct order since you reordered y.
@@ -476,11 +500,11 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
       beta.inits <- inits[["beta"]]
       if (length(beta.inits) != p.occ & length(beta.inits) != 1) {
         if (p.occ == 1) {
-          stop(paste("error: initial values for beta must be of length ", p.occ,
+          stop(paste("initial values for beta must be of length ", p.occ,
 		     sep = ""))
 
         } else {
-          stop(paste("error: initial values for beta must be of length ", p.occ, " or 1",
+          stop(paste("initial values for beta must be of length ", p.occ, " or 1",
 	  	     sep = ""))
         }
       }
@@ -498,10 +522,10 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
       alpha.inits <- inits[["alpha"]]
       if (length(alpha.inits) != p.det & length(alpha.inits) != 1) {
         if (p.det == 1) {
-        stop(paste("error: initial values for alpha must be of length ", p.det,
+        stop(paste("initial values for alpha must be of length ", p.det,
 		   sep = ""))
 	} else {
-          stop(paste("error: initial values for alpha must be of length ", p.det, " or 1",
+          stop(paste("initial values for alpha must be of length ", p.det, " or 1",
 		     sep = ""))
         }
       }
@@ -521,10 +545,10 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
         sigma.sq.psi.inits <- inits[["sigma.sq.psi"]]
         if (length(sigma.sq.psi.inits) != p.occ.re & length(sigma.sq.psi.inits) != 1) {
           if (p.occ.re == 1) {
-            stop(paste("error: initial values for sigma.sq.psi must be of length ", p.occ.re, 
+            stop(paste("initial values for sigma.sq.psi must be of length ", p.occ.re, 
 		       sep = ""))
 	  } else {
-            stop(paste("error: initial values for sigma.sq.psi must be of length ", p.occ.re, 
+            stop(paste("initial values for sigma.sq.psi must be of length ", p.occ.re, 
 		       " or 1", sep = ""))
           }
         }
@@ -550,10 +574,10 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
         sigma.sq.p.inits <- inits[["sigma.sq.p"]]
         if (length(sigma.sq.p.inits) != p.det.re & length(sigma.sq.p.inits) != 1) {
           if (p.det.re == 1) {
-            stop(paste("error: initial values for sigma.sq.p must be of length ", p.det.re, 
+            stop(paste("initial values for sigma.sq.p must be of length ", p.det.re, 
 		     sep = ""))
 	  } else {
-            stop(paste("error: initial values for sigma.sq.p must be of length ", p.det.re, 
+            stop(paste("initial values for sigma.sq.p must be of length ", p.det.re, 
 		       " or 1", sep = ""))
             
           }
@@ -578,7 +602,7 @@ PGOcc <- function(occ.formula, det.formula, data, inits, priors,
     if ("fix" %in% names(inits)) {
       fix.inits <- inits[["fix"]]
       if ((fix.inits != TRUE) & (fix.inits != FALSE)) {
-        stop(paste("error: inits$fix must take value TRUE or FALSE"))
+        stop(paste("inits$fix must take value TRUE or FALSE"))
       }
     } else {
       fix.inits <- FALSE


### PR DESCRIPTION
Hi Jeff,

great package! The speed of the Polyá-Gamma data augmentation is impressive!

Exploring the package, I noticed that PGOcc() will run smoothly even when the number of sites given in y is a just a subset of occ.covs. This can happen, for instance, when users construct their y with melt()/cast() in a scenario where some sites did not have any detection. The mismatch in site numbers between y and occ.covs/det.covs later on throws an error, when trying to do a subsequent PPC with ppcOcc (that's why the brach is called ppcOcc); specifically the error arises in fittedPGOcc().

I have added to the code of PGOcc() two checks (search for code blocks bearing the string 'Heibl' to investigate
them) for consistency between y and occ.covs and between y and det.covs. Maybe you like them.

Also I have removed the string 'error' from all the calls to stop(), because stop adds this automatically.

Cheers,
Christoph


